### PR TITLE
Fix an infinite loop in an example

### DIFF
--- a/examples/fetch/index.js
+++ b/examples/fetch/index.js
@@ -40,7 +40,9 @@ const fetchURL = async () => {
       barFill.style.width = `${received / length * 100}%`
 
       // Keep reading, and keep doing this AS LONG AS IT'S NOT DONE.
-      reader.read().then(onReadChunk)
+      if (!chunk.done) {
+        reader.read().then(onReadChunk)
+      }
     }
 
     // Do the first read().


### PR DESCRIPTION
This fixes an infinite loop in this example. To more clearly see the loop, you can add a console.log statement at the top of the `onReadChunk` function.

Thanks for taking a look, and thank you for these _awesome_ examples! They are really helping me out.